### PR TITLE
feat: expose x,y coordinates of a CurveAffine point

### DIFF
--- a/src/bls12_381/ec.rs
+++ b/src/bls12_381/ec.rs
@@ -197,11 +197,26 @@ macro_rules! curve_impl {
             fn into_xy_unchecked(&self) -> (Self::Base, Self::Base) {
                 (self.x, self.y)
             }
+            fn into_xy(&self) -> Option<(Self::Base, Self::Base)> {
+                if self.is_zero() {
+                    None
+                } else {
+                    Some(self.into_xy_unchecked())
+                }
+            }
             fn from_xy_unchecked(x: Self::Base, y: Self::Base) -> Self {
                 Self {
                     x: x,
                     y: y,
                     infinity: false
+                }
+            }
+            fn from_xy(x: Self::Base, y: Self::Base) -> Option<Self> {
+                let point = Self::from_xy_unchecked(x, y);
+                if point.is_on_curve() {
+                    Some(point)
+                } else {
+                    None
                 }
             }
         }

--- a/src/bls12_381/ec.rs
+++ b/src/bls12_381/ec.rs
@@ -194,6 +194,16 @@ macro_rules! curve_impl {
                 (*self).into()
             }
 
+            fn into_xy_unchecked(&self) -> (Self::Base, Self::Base) {
+                (self.x, self.y)
+            }
+            fn from_xy_unchecked(x: Self::Base, y: Self::Base) -> Self {
+                Self {
+                    x: x,
+                    y: y,
+                    infinity: false
+                }
+            }
         }
 
         impl Rand for $projective {

--- a/src/bn256/ec.rs
+++ b/src/bn256/ec.rs
@@ -194,11 +194,26 @@ macro_rules! curve_impl {
             fn into_xy_unchecked(&self) -> (Self::Base, Self::Base) {
                 (self.x, self.y)
             }
+            fn into_xy(&self) -> Option<(Self::Base, Self::Base)> {
+                if self.is_zero() {
+                    None
+                } else {
+                    Some(self.into_xy_unchecked())
+                }
+            }
             fn from_xy_unchecked(x: Self::Base, y: Self::Base) -> Self {
                 Self {
                     x: x,
                     y: y,
                     infinity: false
+                }
+            }
+            fn from_xy(x: Self::Base, y: Self::Base) -> Option<Self> {
+                let point = Self::from_xy_unchecked(x, y);
+                if point.is_on_curve() {
+                    Some(point)
+                } else {
+                    None
                 }
             }
         }

--- a/src/bn256/ec.rs
+++ b/src/bn256/ec.rs
@@ -190,6 +190,17 @@ macro_rules! curve_impl {
             fn into_projective(&self) -> $projective {
                 (*self).into()
             }
+
+            fn into_xy_unchecked(&self) -> (Self::Base, Self::Base) {
+                (self.x, self.y)
+            }
+            fn from_xy_unchecked(x: Self::Base, y: Self::Base) -> Self {
+                Self {
+                    x: x,
+                    y: y,
+                    infinity: false
+                }
+            }
         }
        
         impl CurveProjective for $projective {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ pub trait Engine: ScalarEngine {
         G2: Into<Self::G2Affine>,
     {
         Self::final_exponentiation(&Self::miller_loop(
-            [(&(p.into().prepare()), &(q.into().prepare()))].into_iter(),
+            [(&(p.into().prepare()), &(q.into().prepare()))].iter(),
         )).unwrap()
     }
 }
@@ -231,6 +231,11 @@ pub trait CurveAffine:
     fn into_uncompressed(&self) -> Self::Uncompressed {
         <Self::Uncompressed as EncodedPoint>::from_affine(*self)
     }
+
+    /// Returns the (x,y) coordinates of the point
+    fn into_xy_unchecked(&self) -> (Self::Base, Self::Base);
+    /// Converts the provided (x,y) coordinates to a `CurveAffine` point
+    fn from_xy_unchecked(x: Self::Base, y: Self::Base) -> Self;
 }
 
 pub trait RawEncodable: CurveAffine {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,8 +234,14 @@ pub trait CurveAffine:
 
     /// Returns the (x,y) coordinates of the point
     fn into_xy_unchecked(&self) -> (Self::Base, Self::Base);
+    /// Returns the (x,y) coordinates of the point.
+    /// Returns `None` for zero points
+    fn into_xy(&self) -> Option<(Self::Base, Self::Base)>;
     /// Converts the provided (x,y) coordinates to a `CurveAffine` point
     fn from_xy_unchecked(x: Self::Base, y: Self::Base) -> Self;
+    /// Converts the provided (x,y) coordinates to a `CurveAffine` point.
+    /// Returns `None` if the point is not on curve
+    fn from_xy(x: Self::Base, y: Self::Base) -> Option<Self>;
 }
 
 pub trait RawEncodable: CurveAffine {


### PR DESCRIPTION
This is cherry-picked from:https://github.com/matter-labs/pairing/tree/112eaf8996ea9f321f44b128e621a6bac92ee101