### PR TITLE
Add constructor to G1/G2 compressed types

### DIFF
--- a/src/bn256/ec.rs
+++ b/src/bn256/ec.rs
@@ -1289,6 +1289,12 @@ pub mod g2 {
     #[derive(Copy, Clone)]
     pub struct G2Compressed([u8; 64]);
 
+    impl G2Compressed {
+        pub fn from_fixed_bytes(bytes: [u8; 64]) -> Self {
+            G2Compressed(bytes)
+        }
+    }
+
     impl AsRef<[u8]> for G2Compressed {
         fn as_ref(&self) -> &[u8] {
             &self.0

--- a/src/bn256/ec.rs
+++ b/src/bn256/ec.rs
@@ -888,6 +888,12 @@ pub mod g1 {
     #[derive(Copy, Clone)]
     pub struct G1Compressed([u8; 32]);
 
+    impl G1Compressed {
+        pub fn from_fixed_bytes(bytes: [u8; 32]) -> Self {
+            G1Compressed(bytes)
+        }
+    }
+
     impl AsRef<[u8]> for G1Compressed {
         fn as_ref(&self) -> &[u8] {
             &self.0


### PR DESCRIPTION
Similar to https://github.com/matter-labs/pairing/pull/10, but applied to `G1Compressed` & `G2Compressed`.